### PR TITLE
Added persistent projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "thyme",
-    "version": "1.7.1",
+    "version": "1.7.2",
     "private": false,
     "homepage": "/",
     "scripts": {

--- a/src/sections/TimeSheet/components/Entry/Entry.js
+++ b/src/sections/TimeSheet/components/Entry/Entry.js
@@ -41,7 +41,7 @@ type EntryProps = {
   onStart?: () => void;
   onStop?: () => void;
   onAdd?: (entry: TimePropertyType) => void;
-  onResetItem?: () => void;
+  onResetItem?: (newItem: boolean) => void;
   onAddNewProject?: (project: string, entry: TimeType | TimePropertyType) => string;
   onRemove?: (entry: TimeType | TimePropertyType) => void;
 };
@@ -134,7 +134,7 @@ class Entry extends Component<EntryProps, EntryState> {
         this.dateInput.focus();
       }
 
-      this.resetItem();
+      this.resetItem(true);
     }
   };
 
@@ -156,13 +156,13 @@ class Entry extends Component<EntryProps, EntryState> {
   };
 
   onClearItem = () => {
-    this.resetItem();
+    this.resetItem(false);
   };
 
-  resetItem() {
+  resetItem(newItem: boolean) {
     const { onResetItem } = this.props;
 
-    if (onResetItem) onResetItem();
+    if (onResetItem) onResetItem(newItem);
   }
 
   updateEntry(newState: any) {

--- a/src/sections/TimeSheet/components/Entry/New.js
+++ b/src/sections/TimeSheet/components/Entry/New.js
@@ -121,14 +121,19 @@ class New extends Component<NewEntryProps, NewEntryState> {
     saveTemporaryItem(timer);
   };
 
-  onResetItem = () => {
+  onResetItem = (newItem: boolean) => {
     const { now } = this.props;
-
-    const entry = defaultState({}, now);
+    const { entry } = this.state;
+    let newEntry;
+    if (newItem) {
+      newEntry = defaultState({ project: entry.project }, now);
+    } else {
+      newEntry = defaultState({}, now);
+    }
 
     this.setState({
       tracking: false,
-      entry,
+      entry: newEntry,
     });
 
     // communicate change of timer

--- a/src/sections/TimeSheet/components/Entry/New.js
+++ b/src/sections/TimeSheet/components/Entry/New.js
@@ -93,7 +93,7 @@ class New extends Component<NewEntryProps, NewEntryState> {
 
     onEntryCreate(entry);
 
-    this.onResetItem();
+    this.onResetItem(false);
   };
 
   onReceiveTimer = (entry: TempTimePropertyType) => {

--- a/src/sections/TimeSheet/components/Entry/New.js
+++ b/src/sections/TimeSheet/components/Entry/New.js
@@ -124,12 +124,8 @@ class New extends Component<NewEntryProps, NewEntryState> {
   onResetItem = (newItem: boolean) => {
     const { now } = this.props;
     const { entry } = this.state;
-    let newEntry;
-    if (newItem) {
-      newEntry = defaultState({ project: entry.project }, now);
-    } else {
-      newEntry = defaultState({}, now);
-    }
+
+    const newEntry = defaultState(newItem ? { project: entry.project } : {}, now);
 
     this.setState({
       tracking: false,


### PR DESCRIPTION
When creating a new entry it defaults to the project that was on the most recent entry, the one that you click the new entry button on. 