### PR TITLE
Fix Intl edge case

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "thyme",
-    "version": "1.91.1",
+    "version": "1.91.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "thyme",
-    "version": "1.91.1",
+    "version": "1.91.2",
     "private": false,
     "license": "MIT",
     "repository": {

--- a/src/core/intl.js
+++ b/src/core/intl.js
@@ -3,7 +3,8 @@
 import parse from 'date-fns/parse';
 
 // determine locale to use
-const locales = ['i-default', ...navigator.languages];
+const navigatorLocales = Array.isArray(navigator.languages) ? navigator.languages : [];
+const locales = ['i-default', ...navigatorLocales];
 const locale = locales.find((l) => {
   try {
     Intl.NumberFormat(l);


### PR DESCRIPTION
In some weird cases the `navigator.languages` seems broken. Add a layer of checks for people with these situations.